### PR TITLE
Fixing "getRevisionOnlyOnce" flag behavior

### DIFF
--- a/src/main/java/org/codehaus/mojo/build/CreateMojo.java
+++ b/src/main/java/org/codehaus/mojo/build/CreateMojo.java
@@ -515,10 +515,9 @@ public class CreateMojo
             // Add the revision and timestamp properties to each project in the reactor
             if ( getRevisionOnlyOnce && reactorProjects != null )
             {
-                Iterator projIter = reactorProjects.iterator();
-                while ( projIter.hasNext() )
+                for ( Object nextProjObj : reactorProjects )
                 {
-                    MavenProject nextProj = (MavenProject) projIter.next();
+                    MavenProject nextProj = (MavenProject) nextProjObj;
                     if ( revision != null )
                     {
                         nextProj.getProperties().put( buildIdPropertyName, revision );

--- a/src/main/java/org/codehaus/mojo/build/CreateMojo.java
+++ b/src/main/java/org/codehaus/mojo/build/CreateMojo.java
@@ -521,8 +521,8 @@ public class CreateMojo
                     MavenProject nextProj = (MavenProject) projIter.next();
                     if ( revision != null )
                     {
-                        project.getProperties().put( buildIdPropertyName, revision );
-                        project.getProperties().put( buildNumberPropertyName, formatBuildNumber(commitNumber) );
+                        nextProj.getProperties().put( buildIdPropertyName, revision );
+                        nextProj.getProperties().put( buildNumberPropertyName, formatBuildNumber(commitNumber) );
                     }
                     nextProj.getProperties().put( this.timestampPropertyName, timestamp );
                     nextProj.getProperties().put( this.scmBranchPropertyName, scmBranch );


### PR DESCRIPTION
Before this fix CreateMojo did not save buildId and buildNumber properties for next reactor projects.
